### PR TITLE
Reset ManufacturerCreateModal after success

### DIFF
--- a/components/manufacturers/ManufacturerCreateModal.vue
+++ b/components/manufacturers/ManufacturerCreateModal.vue
@@ -57,6 +57,11 @@ export default {
           type: 'is-success',
         })
         this.$emit('manufacturerCreated', resp.data.slug)
+        this.errors = {}
+        this.manufacturer = {
+          name: '',
+          slug: null,
+        }
         this.modal = false
       } catch (error) {
         if (error.response) {


### PR DESCRIPTION
Using the modal several times in a row would result in the previous values and errors being present.