### PR TITLE
Wait until table is loaded before showing empty table message

### DIFF
--- a/components/manufacturers/ManufacturerTableInner.vue
+++ b/components/manufacturers/ManufacturerTableInner.vue
@@ -1,7 +1,7 @@
 <template>
   <section>
     <b-table
-      v-if="data.length > 0"
+      v-if="data.length > 0 || loading"
       :data="data"
       :loading="loading"
       :total="total"


### PR DESCRIPTION
Previously this would flash up instead of the table loading symbol